### PR TITLE
URL Model

### DIFF
--- a/app/models/short_url.rb
+++ b/app/models/short_url.rb
@@ -1,10 +1,10 @@
 class ShortUrl < ApplicationRecord
-
-  CHARACTERS = [*'0'..'9', *'a'..'z', *'A'..'Z'].freeze
-
-  validate :validate_full_url
+  validates :full_url, presence: true
+  validates_with Validators::FullUrlValidator
+  after_create :encode_short_code
 
   def short_code
+    UrlEncoder.new(self.id).call unless self.id.nil?
   end
 
   def update_title!
@@ -12,7 +12,8 @@ class ShortUrl < ApplicationRecord
 
   private
 
-  def validate_full_url
+  def encode_short_code
+    self.short_code = UrlEncoder.new(self.id).call
+    self.save
   end
-
 end

--- a/app/models/validators/full_url_validator.rb
+++ b/app/models/validators/full_url_validator.rb
@@ -1,0 +1,13 @@
+class Validators::FullUrlValidator < ActiveModel::Validator
+  VALID_URL_REGEX = /(^http[s]?:\/{2}|(^www)|(^\/{1,2}))/
+
+  def validate(record)
+    record.errors.add(:full_url, 'is not a valid url') unless valid?(record)
+  end
+
+  private
+
+  def valid?(record)
+    !record.full_url.blank? && record.full_url.match?(VALID_URL_REGEX)
+  end
+end

--- a/db/migrate/20201117153546_add_short_code_to_short_urls.rb
+++ b/db/migrate/20201117153546_add_short_code_to_short_urls.rb
@@ -1,0 +1,5 @@
+class AddShortCodeToShortUrls < ActiveRecord::Migration[6.0]
+  def change
+    add_column :short_urls, :short_code, :string, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_23_133432) do
+ActiveRecord::Schema.define(version: 2020_11_17_153546) do
 
   create_table "short_urls", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "full_url"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2019_09_23_133432) do
     t.integer "click_count", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "short_code"
     t.index ["full_url"], name: "index_short_urls_on_full_url"
   end
 


### PR DESCRIPTION
* I added the missing short_code column through a Rails migration with an index because this field will be queried as well

* Use the UrlEncoder service inside the #short_code method in the ShortUrl model to be able to encode the URLs on the fly based on the current table ID

* Use a Regex expression to be able to tell if the url of a ShortUrl model is valid or not. The Regex validates if the URL contains the following patterns at the beginning of the url: 'https', 'http', 'www', '/' or '//'.

* Create a Custom Validator class 'Validators::FullUrlValidator' to extract the validation logic from the model

* Add the after_create callback to be able to set the short_code value after the ID of the record is generated