### PR TITLE
URL Controller

### DIFF
--- a/app/controllers/short_urls_controller.rb
+++ b/app/controllers/short_urls_controller.rb
@@ -4,12 +4,27 @@ class ShortUrlsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def index
+    render json: { urls: ShortUrl.top(100).map(&:public_attributes) }, status: :ok
   end
 
   def create
+    @url = ShortUrl.new(full_url: params[:full_url])
+
+    if @url.save
+      render json: @url, status: :created
+    else
+      render json: { errors: @url.errors.full_messages }, status: :unprocessable_entity
+    end
   end
 
   def show
-  end
+    @url = ShortUrl.find_by(id: UrlDecoder.new(params[:id]).call)
 
+    if @url
+      UrlClickIncrementer.new(@url, increment: 1).call
+      redirect_to @url.full_url
+    else
+      render json: {}, status: :not_found
+    end
+  end
 end

--- a/app/models/short_url.rb
+++ b/app/models/short_url.rb
@@ -2,18 +2,32 @@ class ShortUrl < ApplicationRecord
   validates :full_url, presence: true
   validates_with Validators::FullUrlValidator
   after_create :encode_short_code
+  scope :top, -> (limit) { order(click_count: :desc).limit(limit) }
 
   def short_code
-    UrlEncoder.new(self.id).call unless self.id.nil?
+    encoder_service.call unless self.id.nil?
   end
 
   def update_title!
   end
 
+  def public_attributes
+    {
+        title: self.title,
+        full_url: self.full_url,
+        short_code: self.short_code,
+        click_count: self.click_count
+    }
+  end
+
   private
 
   def encode_short_code
-    self.short_code = UrlEncoder.new(self.id).call
+    self.short_code = encoder_service.call
     self.save
+  end
+
+  def encoder_service
+    UrlEncoder.new(self.id)
   end
 end

--- a/app/services/url_click_incrementer.rb
+++ b/app/services/url_click_incrementer.rb
@@ -1,0 +1,18 @@
+class UrlClickIncrementer
+
+  def initialize(url, params)
+    @url = url
+    @incrementer = params[:increment]
+  end
+
+  def call
+    increment_click_count
+  end
+
+  private
+
+  def increment_click_count
+    @url.click_count += @incrementer
+    @url.save
+  end
+end

--- a/spec/controllers/short_urls_controller_spec.rb
+++ b/spec/controllers/short_urls_controller_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe ShortUrlsController, type: :controller do
 
     it "has a list of the top 100 urls" do
       get :index, format: :json
-
-      expect(parsed_response['urls']).to be_include(short_url.public_attributes)
+      # Chained stringify_keys method to make both hashes to match
+      expect(parsed_response['urls']).to be_include(short_url.public_attributes.stringify_keys)
     end
 
   end


### PR DESCRIPTION
* Added the 'top' scope to the ShortUrl model to be able to fetch the data sorted by the 'click_count' in a descending way to get the most visited ShortUrls from top to bottom

* Implemented the requested actions in the 'ShortUrlsController' based on the input from the Rspec Controller tests using json as the format response

* Implemented 'UrlClickIncrementer' service to handle the increment of the click_counts of a 'ShortUrl' model. This extracts the responsability from the Controller into the Service. I could have just let the logic in the Controller but it is not the Controller responsability to do such tasks. Besides the Controller logic looks cleaner

* Chained 'stringify_keys' method inside the ShortUrlsController class for the 'get index' call. This is because the JSON parsed response was returning an array of hashes with String as keys while the '#public_attributes' method was returning a hash with Symbol as keys and therefore the assertion in the test was failing. By calling the 'stringify_keys' both hashes matched as expected